### PR TITLE
Availability / Busy Times:

### DIFF
--- a/agents/planning.py
+++ b/agents/planning.py
@@ -602,20 +602,21 @@ def _format_member(member: dict[str, Any]) -> str:
         _, scan = sanitise_input(field_val, field_name=field_name)
         if scan.signals:
             logger.warning("Prompt-injection signal in member field: %s", scan.signals)
-    return (
+    typical = member.get("typical_locations") or []
+    typical_s = "; ".join(typical) if typical else ""
+    base = (
         f"- {member.get('name') or member.get('email')}: "
-        f"location={member.get('default_location') or 'unknown'}, "
         f"budget={member.get('budget_preference') or 'unspecified'}, "
         f"likes={likes_s}, dislikes={dislikes_s}"
     )
+    if typical_s:
+        base += f", typical_places=[{typical_s}]"
+    return base
 
 
 def _base_location_from_context(context: dict[str, Any]) -> str:
-    for member in context["members"]:
-        location = member.get("default_location")
-        if location:
-            return str(location)
-    return "Boston, MA"
+    """The app is scoped to Boston / Greater Boston."""
+    return "Boston and Greater Boston, MA"
 
 
 def _build_fallback_plans(
@@ -924,6 +925,50 @@ def _extract_web_results_from_tool_messages(
     return results
 
 
+_WEB_TITLE_SITE_SUFFIX_RE = re.compile(
+    r"\s*[-–—|]\s*("
+    r"Yelp|Eventbrite|Quora|TripAdvisor|Atlas Obscura|Reddit|"
+    r"Facebook|Timeout|Time Out|Lonely Planet|Foursquare|"
+    r"Google|Wikipedia|YouTube|Medium|Tripadvisor"
+    r").*$",
+    re.IGNORECASE,
+)
+
+_WEB_TITLE_LISTICLE_RE = re.compile(
+    r"^(THE\s+)?\d+\s+(BEST|Cool|Amazing|Awesome|Top|Great|Fun|Unusual|Must|Essential|Ultimate)",
+    re.IGNORECASE,
+)
+
+
+def _clean_web_title(raw_title: str) -> str | None:
+    """Clean a web search result title into a usable plan title.
+
+    Returns None if the title is a listicle/article heading that cannot
+    be meaningfully cleaned (those results should be skipped).
+    """
+    cleaned = _WEB_TITLE_SITE_SUFFIX_RE.sub("", raw_title).strip()
+    if not cleaned:
+        return None
+    if _WEB_TITLE_LISTICLE_RE.match(cleaned):
+        return None
+    # Skip titles that look like generic article headlines
+    lower = cleaned.lower()
+    if any(
+        phrase in lower
+        for phrase in [
+            "things to do",
+            "what to do",
+            "hidden gems",
+            "local's guide",
+            "locals guide",
+            "complete guide",
+            "travel guide",
+        ]
+    ):
+        return None
+    return cleaned[:120]
+
+
 def _build_web_grounded_fallback_plans(
     context: dict[str, Any],
     web_results: list[dict[str, Any]],
@@ -950,7 +995,7 @@ def _build_web_grounded_fallback_plans(
         prior_venues=prior_venues,
         novelty_target=novelty_target,
         label_getter=lambda result: str(result.get("title") or ""),
-        max_items=5,
+        max_items=10,  # Fetch extra so we can skip unusable titles
         priority_score_getter=lambda result: _venue_prior_score(
             str(result.get("title") or ""),
             prior_scores,
@@ -959,19 +1004,25 @@ def _build_web_grounded_fallback_plans(
 
     plans: list[dict[str, Any]] = []
     for idx, result in enumerate(selected_results):
-        title = result.get("title") or f"Web Option {idx + 1}"
+        if len(plans) >= 5:
+            break
+        raw_title = result.get("title") or ""
+        cleaned_title = _clean_web_title(raw_title)
+        if cleaned_title is None:
+            # Skip listicle / article titles — will be padded by generic fallback
+            continue
         snippet = result.get("snippet") or "Candidate discovered from web search."
         source = result.get("source") or result.get("link") or "web"
-        title_token = _normalize_venue_token(title)
-        prior_score = _venue_prior_score(str(title), prior_scores)
+        title_token = _normalize_venue_token(cleaned_title)
+        prior_score = _venue_prior_score(cleaned_title, prior_scores)
         plans.append(
             {
-                "title": str(title)[:120],
+                "title": cleaned_title,
                 "description": f"{str(snippet)[:260]}",
-                "vibe_type": DEFAULT_VIBES[idx],
-                "date_time": datetime.utcnow() + timedelta(days=7 + idx),
+                "vibe_type": DEFAULT_VIBES[len(plans)],
+                "date_time": datetime.utcnow() + timedelta(days=7 + len(plans)),
                 "location": base_location,
-                "venue_name": str(title)[:120],
+                "venue_name": cleaned_title,
                 "estimated_cost": "$20-40 per person",
                 "logistics": {
                     "source": "web_fallback",
@@ -1000,6 +1051,9 @@ def _build_web_grounded_fallback_plans(
             if len(plans) >= 5:
                 break
             plans.append(plan)
+
+    if not plans:
+        return None
 
     return plans[:5]
 
@@ -1036,7 +1090,7 @@ def _build_web_fallback_queries(
         activity_seeds.append("activities matching group voting feedback")
 
     descriptor_seeds = {
-        "budget_friendly": "affordable activities",
+        "budget_friendly": "free activities parks cheap eats",
         "short_travel": "activities close to downtown",
         "more_active": "active group activities",
         "more_chill": "quiet hangout spots",
@@ -1085,7 +1139,7 @@ def _build_maps_fallback_queries(
         activity_seeds.append("activities matching group voting feedback")
 
     descriptor_seeds = {
-        "budget_friendly": "cheap eats",
+        "budget_friendly": "free things to do",
         "short_travel": "near city center",
         "more_active": "sports activity",
         "more_chill": "cafe",
@@ -1238,9 +1292,38 @@ async def _load_group_context(group_id: UUID) -> dict[str, Any]:
         group_id,
     )
 
+    # Enrich members with typical locations from their availability blocks
+    # so the AI can suggest venues near where members usually are.
+    day_names = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    member_dicts = []
+    for m in members:
+        md = dict(m)
+        avail_blocks = await db.fetch(
+            """
+            SELECT day_of_week, start_time, end_time, label, location
+            FROM availability_blocks
+            WHERE user_id = $1 AND location IS NOT NULL AND location != ''
+            ORDER BY day_of_week, start_time
+            """,
+            m["id"],
+        )
+        if avail_blocks:
+            places = []
+            for ab in avail_blocks:
+                day_str = day_names[ab["day_of_week"]] if 0 <= ab["day_of_week"] <= 6 else "?"
+                start = str(ab["start_time"])[:5] if ab["start_time"] else ""
+                end = str(ab["end_time"])[:5] if ab["end_time"] else ""
+                label = ab["label"] or ""
+                loc = ab["location"]
+                places.append(
+                    f"{day_str} {start}-{end}: {loc}" + (f" ({label})" if label else "")
+                )
+            md["typical_locations"] = places
+        member_dicts.append(md)
+
     return {
         "group": dict(group),
-        "members": [dict(m) for m in members],
+        "members": member_dicts,
         "recent_events": [dict(e) for e in recent_events],
     }
 
@@ -1287,6 +1370,12 @@ def _build_prompt(
             + "\n".join(f"- {descriptor}" for descriptor in descriptors)
             + "\n"
         )
+        if "budget_friendly" in descriptors:
+            descriptor_block += (
+                "\nHARD CONSTRAINT: Every plan's estimated_cost MUST be under $15/person. "
+                "If the group budget preference is set, go even lower. "
+                "Prioritize free activities, parks, and cheap eats.\n"
+            )
 
     lead_focus_block = ""
     if refinement_focus_note:
@@ -1336,6 +1425,7 @@ def _build_prompt(
 
     return f"""
 Group name: {context['group']['name']}
+Location context: All activities MUST be in Boston and Greater Boston, MA area.
 
 Members:
 {member_lines}

--- a/services/availability_group_service.py
+++ b/services/availability_group_service.py
@@ -1,4 +1,8 @@
-"""Group availability domain service."""
+"""Group availability domain service.
+
+Returns common free slots as **weekday-based patterns** (e.g. "Monday 5 PM – 9 PM")
+clipped to sensible plannable hours (8 AM – 11 PM).
+"""
 
 from __future__ import annotations
 
@@ -8,122 +12,120 @@ from uuid import UUID
 from database import db
 from services.group_access import require_active_group_member
 
+# Only show free slots within these hours (Issue 10: filter overnight).
+PLANNABLE_START = time(8, 0)
+PLANNABLE_END = time(23, 0)
 
-def _expand_blocks_to_intervals(
-    blocks: list, time_min: datetime, time_max: datetime
-) -> list[tuple[datetime, datetime]]:
-    intervals = []
-    for block in blocks:
-        day_of_week = block["day_of_week"]
-        start_t = block["start_time"]
-        end_t = block["end_time"]
-
-        if isinstance(start_t, str):
-            hour, minute = map(int, start_t.split(":")[:2])
-            start_t = time(hour, minute)
-        if isinstance(end_t, str):
-            hour, minute = map(int, end_t.split(":")[:2])
-            end_t = time(hour, minute)
-
-        current = time_min.replace(hour=0, minute=0, second=0, microsecond=0)
-        target_weekday = (day_of_week + 6) % 7
-        while current <= time_max:
-            if current.weekday() == target_weekday:
-                start_dt = datetime.combine(current.date(), start_t)
-                end_dt = datetime.combine(current.date(), end_t)
-                if start_dt < time_max and end_dt > time_min:
-                    intervals.append((max(start_dt, time_min), min(end_dt, time_max)))
-            current += timedelta(days=1)
-    return intervals
+DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
 
-def _merge_overlapping(
-    intervals: list[tuple[datetime, datetime]],
-) -> list[tuple[datetime, datetime]]:
-    if not intervals:
-        return []
-    sorted_intervals = sorted(intervals)
-    merged = [sorted_intervals[0]]
-    for start, end in sorted_intervals[1:]:
-        if start <= merged[-1][1]:
-            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-        else:
-            merged.append((start, end))
-    return merged
+def _time_to_str(t: time) -> str:
+    """Format time as '5:00 PM'."""
+    hour = t.hour
+    minute = t.minute
+    ampm = "AM" if hour < 12 else "PM"
+    display_hour = hour % 12 or 12
+    if minute == 0:
+        return f"{display_hour}:00 {ampm}"
+    return f"{display_hour}:{minute:02d} {ampm}"
 
 
-def _split_slot_by_day(
-    slot_start: datetime, slot_end: datetime, slot_hours: float
+def _parse_time(raw: str | time) -> time:
+    if isinstance(raw, time):
+        return raw
+    parts = raw.split(":")[:2]
+    return time(int(parts[0]), int(parts[1]))
+
+
+def _compute_weekday_free_slots(
+    all_blocks: dict[str, list[dict]],
 ) -> list[dict]:
-    split_slots = []
-    current = slot_start
-    while current < slot_end:
-        day_end = current.replace(hour=23, minute=59, second=59, microsecond=999)
-        chunk_end = min(day_end, slot_end)
-        if (chunk_end - current).total_seconds() >= slot_hours * 3600:
-            split_slots.append(
-                {
-                    "start": current.isoformat(),
-                    "end": chunk_end.isoformat(),
-                }
-            )
-        current = datetime.combine(chunk_end.date() + timedelta(days=1), time(0, 0, 0))
-    return split_slots
+    """Compute common free slots per weekday across all users.
 
+    For each day of the week (0=Sun..6=Sat):
+    1. Collect each user's busy intervals on that day.
+    2. Find gaps where ALL users are free.
+    3. Clip to plannable hours and filter out short (<1h) slots.
 
-def _find_common_free(
-    all_busy: dict, time_min: datetime, time_max: datetime, slot_hours: float = 2
-) -> list[dict]:
-    if not all_busy:
-        return [{"start": time_min.isoformat(), "end": time_max.isoformat()}]
+    Returns list of {day_of_week, day_name, start_time, end_time}.
+    """
+    results: list[dict] = []
 
-    merged = {uid: _merge_overlapping(busy) for uid, busy in all_busy.items()}
+    for dow in range(7):
+        # Collect busy intervals for this day of week per user.
+        user_busy: dict[str, list[tuple[time, time]]] = {}
+        for uid, blocks in all_blocks.items():
+            intervals = []
+            for block in blocks:
+                if block["day_of_week"] == dow:
+                    s = _parse_time(block["start_time"])
+                    e = _parse_time(block["end_time"])
+                    if s < e:
+                        intervals.append((s, e))
+            user_busy[uid] = intervals
 
-    all_starts = []
-    all_ends = []
-    for busy_slots in merged.values():
-        for start, end in busy_slots:
-            all_starts.append(start)
-            all_ends.append(end)
+        if not user_busy:
+            continue
 
-    if not all_starts:
-        return [{"start": time_min.isoformat(), "end": time_max.isoformat()}]
+        # Merge all busy intervals across all users into one timeline.
+        all_intervals: list[tuple[time, time]] = []
+        for intervals in user_busy.values():
+            all_intervals.extend(intervals)
 
-    events = sorted([(start, 1) for start in all_starts] + [(end, -1) for end in all_ends])
-    count = 0
-    gap_start = None
-    free_slots = []
-    for moment, delta in events:
-        count += delta
-        if count == 0:
-            gap_start = moment
-        elif gap_start and count == 1:
-            if (moment - gap_start).total_seconds() >= slot_hours * 3600:
-                if (moment - gap_start).total_seconds() > 24 * 3600:
-                    free_slots.extend(_split_slot_by_day(gap_start, moment, slot_hours))
-                else:
-                    free_slots.append(
-                        {
-                            "start": gap_start.isoformat(),
-                            "end": moment.isoformat(),
-                        }
-                    )
-            gap_start = None
-    return free_slots[:15]
+        if not all_intervals:
+            # Everyone is free all day — return the plannable window.
+            results.append({
+                "day_of_week": dow,
+                "day_name": DAY_NAMES[dow],
+                "start_time": _time_to_str(PLANNABLE_START),
+                "end_time": _time_to_str(PLANNABLE_END),
+            })
+            continue
 
+        # Sweep-line on this weekday to find free gaps.
+        events: list[tuple[int, int]] = []  # (minutes_since_midnight, +1/-1)
+        for s, e in all_intervals:
+            events.append((s.hour * 60 + s.minute, 1))
+            events.append((e.hour * 60 + e.minute, -1))
+        events.sort(key=lambda x: (x[0], -x[1]))
 
-def _parse_window(
-    time_min: str | None,
-    time_max: str | None,
-) -> tuple[datetime, datetime]:
-    now = datetime.utcnow()
-    start = datetime.fromisoformat(time_min.replace("Z", "+00:00")) if time_min else now
-    end = (
-        datetime.fromisoformat(time_max.replace("Z", "+00:00"))
-        if time_max
-        else now + timedelta(days=7)
-    )
-    return start, end
+        # Find gaps where count == 0 (nobody busy).
+        plannable_start_min = PLANNABLE_START.hour * 60 + PLANNABLE_START.minute
+        plannable_end_min = PLANNABLE_END.hour * 60 + PLANNABLE_END.minute
+
+        count = 0
+        gap_start: int | None = plannable_start_min  # Start of day (plannable)
+        free_gaps: list[tuple[int, int]] = []
+
+        for moment, delta in events:
+            if gap_start is not None and count == 0 and moment > gap_start:
+                free_gaps.append((gap_start, moment))
+            count += delta
+            if count == 0:
+                gap_start = moment
+            else:
+                gap_start = None
+
+        # Close final gap to end of plannable day.
+        if gap_start is not None and count == 0 and plannable_end_min > gap_start:
+            free_gaps.append((gap_start, plannable_end_min))
+
+        # Clip to plannable hours and filter short slots.
+        for gap_s, gap_e in free_gaps:
+            clipped_s = max(gap_s, plannable_start_min)
+            clipped_e = min(gap_e, plannable_end_min)
+            duration_hours = (clipped_e - clipped_s) / 60
+            if duration_hours >= 1.0:
+                start_t = time(clipped_s // 60, clipped_s % 60)
+                end_t = time(clipped_e // 60, clipped_e % 60)
+                results.append({
+                    "day_of_week": dow,
+                    "day_name": DAY_NAMES[dow],
+                    "start_time": _time_to_str(start_t),
+                    "end_time": _time_to_str(end_t),
+                })
+
+    return results
 
 
 async def compute_group_availability(
@@ -134,14 +136,12 @@ async def compute_group_availability(
 ) -> dict[str, object]:
     await require_active_group_member(group_id, user_id)
 
-    start, end = _parse_window(time_min, time_max)
-
     members = await db.fetch(
         "SELECT user_id FROM group_members WHERE group_id = $1 AND status = 'active'",
         group_id,
     )
 
-    all_busy = {}
+    all_blocks: dict[str, list[dict]] = {}
     for member in members:
         blocks = await db.fetch(
             """
@@ -151,12 +151,11 @@ async def compute_group_availability(
             """,
             member["user_id"],
         )
-        intervals = _expand_blocks_to_intervals([dict(block) for block in blocks], start, end)
-        all_busy[str(member["user_id"])] = intervals
+        all_blocks[str(member["user_id"])] = [dict(block) for block in blocks]
 
-    common_free = _find_common_free(all_busy, start, end)
+    common_free = _compute_weekday_free_slots(all_blocks)
     return {
         "common_slots": common_free,
-        "per_user_busy": {uid: len(busy) for uid, busy in all_busy.items()},
+        "per_user_busy": {uid: len(blocks) for uid, blocks in all_blocks.items()},
     }
 

--- a/services/group_service.py
+++ b/services/group_service.py
@@ -114,16 +114,25 @@ async def get_group(group_id: UUID, user_id: UUID) -> dict[str, object]:
         """
         SELECT id, iteration, status, voting_deadline, created_at
         FROM plan_rounds
-        WHERE group_id = $1 AND status = 'voting_open'
+        WHERE group_id = $1 AND status IN ('voting_open', 'votes_complete')
         ORDER BY created_at DESC
         LIMIT 1
         """,
         group_id,
     )
 
+    # Fetch vote counts for active rounds (for Rec B: vote progress).
+    round_vote_counts: dict[str, int] = {}
+    for r in rounds:
+        vote_count = await db.fetchval(
+            "SELECT COUNT(*) FROM votes WHERE plan_round_id = $1", r["id"]
+        )
+        round_vote_counts[str(r["id"])] = vote_count or 0
+
     events = await db.fetch(
         """
-        SELECT e.id, e.event_date, p.title as plan_title
+        SELECT e.id, e.event_date, p.title as plan_title, p.location as plan_location,
+               (SELECT COUNT(*) FROM feedback f WHERE f.event_id = e.id) as feedback_count
         FROM events e
         JOIN plans p ON e.plan_id = p.id
         WHERE e.group_id = $1
@@ -144,13 +153,26 @@ async def get_group(group_id: UUID, user_id: UUID) -> dict[str, object]:
     )
     preferences = {}
     if prefs_row:
+        # JSONB columns may come back as Python lists (asyncpg) or as
+        # JSON strings in some edge cases.  Normalise to list[str].
+        likes_raw = prefs_row["activity_likes"]
+        dislikes_raw = prefs_row["activity_dislikes"]
+        if isinstance(likes_raw, str):
+            try:
+                likes_raw = json.loads(likes_raw)
+            except (json.JSONDecodeError, TypeError):
+                likes_raw = []
+        if isinstance(dislikes_raw, str):
+            try:
+                dislikes_raw = json.loads(dislikes_raw)
+            except (json.JSONDecodeError, TypeError):
+                dislikes_raw = []
+
         preferences = {
             "default_location": prefs_row["default_location"],
-            "activity_likes": prefs_row["activity_likes"]
-            if prefs_row["activity_likes"] is not None
-            else [],
-            "activity_dislikes": prefs_row["activity_dislikes"]
-            if prefs_row["activity_dislikes"] is not None
+            "activity_likes": likes_raw if isinstance(likes_raw, list) else [],
+            "activity_dislikes": dislikes_raw
+            if isinstance(dislikes_raw, list)
             else [],
             "meetup_frequency": prefs_row["meetup_frequency"],
             "budget_preference": prefs_row["budget_preference"],
@@ -200,6 +222,7 @@ async def get_group(group_id: UUID, user_id: UUID) -> dict[str, object]:
         ],
         "max_members": MAX_GROUP_MEMBERS,
         "slots_remaining": slots_remaining,
+        "total_members": active_member_count,
         "current_plans": [
             {
                 "round_id": str(r["id"]),
@@ -208,6 +231,7 @@ async def get_group(group_id: UUID, user_id: UUID) -> dict[str, object]:
                 "voting_deadline": r["voting_deadline"].isoformat()
                 if r["voting_deadline"]
                 else None,
+                "votes_in": round_vote_counts.get(str(r["id"]), 0),
             }
             for r in rounds
         ],
@@ -216,6 +240,8 @@ async def get_group(group_id: UUID, user_id: UUID) -> dict[str, object]:
                 "id": str(e["id"]),
                 "event_date": e["event_date"].isoformat(),
                 "plan_title": e["plan_title"],
+                "location": e["plan_location"],
+                "feedback_count": e["feedback_count"] or 0,
             }
             for e in events
         ],

--- a/services/plans_service.py
+++ b/services/plans_service.py
@@ -16,6 +16,7 @@ from config import get_settings
 from database import db
 from services.errors import BadRequestError, NotFoundError, UpstreamServiceError
 from services.group_access import require_active_group_member, require_group_lead
+from utils.email import send_voting_open_email, send_event_finalized_email
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,14 @@ DEFAULT_EVENT_OFFSET_DAYS = 7
 RECENT_VENUE_LIMIT = 40
 
 REFINEMENT_DESCRIPTOR_GUIDANCE: dict[str, str] = {
-    "budget_friendly": "Prefer lower cost and better value options.",
+    "budget_friendly": (
+        "CRITICAL BUDGET CONSTRAINT: The group selected 'budget friendly'. "
+        "ALL 5 plans MUST have estimated cost under $15 per person. "
+        "Prioritize: free activities (parks, public spaces, free museum days, "
+        "community events), picnics, hiking, free outdoor concerts, "
+        "cheap eats under $10, BYOB gatherings, and other low/no-cost options. "
+        "Do NOT suggest restaurants with entrees over $12 or any paid attractions over $10."
+    ),
     "short_travel": "Minimize travel time and distance for most members.",
     "more_active": "Bias toward higher-energy, activity-heavy options.",
     "more_chill": "Bias toward calmer, conversation-friendly options.",
@@ -55,6 +63,90 @@ def _first_choice_counts(votes: list) -> dict[str, int]:
             first_choice = rankings[0]
             counts[first_choice] = counts.get(first_choice, 0) + 1
     return counts
+
+
+def _borda_scores(votes: list, num_plans: int = 5) -> dict[str, float]:
+    """Compute Borda count scores. Rank 1 gets num_plans points, rank 2 gets num_plans-1, etc."""
+    scores: dict[str, float] = {}
+    for vote in votes:
+        rankings = _parse_rankings(vote["rankings"])
+        for position, plan_id in enumerate(rankings):
+            points = max(0, num_plans - position)
+            scores[plan_id] = scores.get(plan_id, 0) + points
+    return scores
+
+
+def _top_n_sets(votes: list, n: int = 3) -> list[set[str]]:
+    """Return the top-N plan IDs for each vote as a list of sets."""
+    result = []
+    for vote in votes:
+        rankings = _parse_rankings(vote["rankings"])
+        result.append(set(rankings[:n]))
+    return result
+
+
+def _determine_consensus(
+    votes: list, total_members: int
+) -> tuple[bool, str | None, dict[str, int]]:
+    """Determine consensus using a multi-strategy approach.
+
+    Strategy 1: First-choice strict majority (>50%).
+    Strategy 2: Borda count — if top scorer leads by a scaled margin AND
+                all voters have that plan in their top 3.
+    Strategy 3: Borda tie-break for small groups (≤3 voters) — if the top
+                Borda scores are tied and both candidates are in every
+                voter's top 3, pick the one with more first-choice votes.
+
+    Returns (consensus, winning_plan_id, first_choice_counts).
+    """
+    first_choices = _first_choice_counts(votes)
+
+    if not first_choices or not total_members:
+        return False, None, first_choices
+
+    # Strategy 1: First-choice majority
+    max_votes = max(first_choices.values())
+    if max_votes >= (total_members / 2) + 1:
+        winner = max(first_choices, key=first_choices.get)  # type: ignore[arg-type]
+        return True, winner, first_choices
+
+    # Strategy 2: Borda count with top-3 overlap
+    if len(votes) >= 2:
+        borda = _borda_scores(votes)
+        if borda:
+            sorted_borda = sorted(borda.items(), key=lambda x: x[1], reverse=True)
+            best_id, best_score = sorted_borda[0]
+            second_score = sorted_borda[1][1] if len(sorted_borda) > 1 else 0
+
+            # Scale margin by voter count: 2 voters → 1, 3+ → 2
+            min_margin = max(1, len(votes) - 1)
+            if best_score - second_score >= min_margin:
+                # Check that every voter has this plan in their top 3
+                top3_sets = _top_n_sets(votes, n=3)
+                if all(best_id in voter_top3 for voter_top3 in top3_sets):
+                    return True, best_id, first_choices
+
+            # Strategy 3: Borda tie-break for small groups
+            if len(votes) <= 3 and len(sorted_borda) >= 2:
+                if best_score == second_score:
+                    top3_sets = _top_n_sets(votes, n=3)
+                    candidates = [
+                        cid for cid, sc in sorted_borda if sc == best_score
+                    ]
+                    viable = [
+                        c
+                        for c in candidates
+                        if all(c in t3 for t3 in top3_sets)
+                    ]
+                    if viable:
+                        # Tiebreak: most first-choice votes, then plan_id
+                        winner = max(
+                            viable,
+                            key=lambda c: (first_choices.get(c, 0), c),
+                        )
+                        return True, winner, first_choices
+
+    return False, None, first_choices
 
 
 def _clamp_novelty_target(value: float, default: float) -> float:
@@ -203,8 +295,18 @@ async def _insert_generated_plans(
 
 
 async def _create_generation_round(group_id: UUID) -> tuple[UUID, int, datetime]:
+    # Only count rounds created after the most recent finalized event so that
+    # each hangout cycle starts at Round 1.
     max_iter = await db.fetchval(
-        "SELECT COALESCE(MAX(iteration), 0) FROM plan_rounds WHERE group_id = $1",
+        """
+        SELECT COALESCE(MAX(pr.iteration), 0)
+        FROM plan_rounds pr
+        WHERE pr.group_id = $1
+          AND pr.created_at > COALESCE(
+            (SELECT MAX(e.created_at) FROM events e WHERE e.group_id = $1),
+            '1970-01-01'::timestamptz
+          )
+        """,
         group_id,
     )
     iteration = (max_iter or 0) + 1
@@ -271,12 +373,39 @@ async def generate_plans(group_id: UUID, user_id: UUID) -> dict[str, object]:
         )
         raise UpstreamServiceError("Plan generation failed") from exc
 
+    # Notify all group members that voting is open.
+    await _send_voting_notifications(group_id, round_id)
+
     return {
         "plan_round_id": str(round_id),
         "plans": plans_data,
         "status": "voting_open",
         "voting_deadline": voting_deadline.isoformat(),
     }
+
+
+async def _send_voting_notifications(group_id: UUID, round_id: UUID) -> None:
+    """Send voting-open emails to all active group members."""
+    try:
+        group = await db.fetchrow("SELECT name FROM groups WHERE id = $1", group_id)
+        group_name = group["name"] if group else "your group"
+        members = await db.fetch(
+            """
+            SELECT u.email FROM group_members gm
+            JOIN users u ON gm.user_id = u.id
+            WHERE gm.group_id = $1 AND gm.status = 'active'
+            """,
+            group_id,
+        )
+        for member in members:
+            send_voting_open_email(
+                to_email=member["email"],
+                group_name=group_name,
+                group_id=str(group_id),
+                round_id=str(round_id),
+            )
+    except Exception:
+        logger.exception("Failed to send voting notification emails for group %s", group_id)
 
 
 async def get_plans(group_id: UUID, round_id: UUID, user_id: UUID) -> dict[str, object]:
@@ -327,7 +456,7 @@ async def submit_vote(
     await require_active_group_member(group_id, user_id)
 
     round_row = await db.fetchrow(
-        "SELECT id FROM plan_rounds WHERE id = $1 AND group_id = $2 AND status = 'voting_open'",
+        "SELECT id FROM plan_rounds WHERE id = $1 AND group_id = $2 AND status IN ('voting_open', 'votes_complete')",
         round_id,
         group_id,
     )
@@ -356,6 +485,21 @@ async def submit_vote(
         notes,
     )
 
+    # Check if all active members have now voted; if so, close voting.
+    total_members = await db.fetchval(
+        "SELECT COUNT(*) FROM group_members WHERE group_id = $1 AND status = 'active'",
+        group_id,
+    )
+    total_votes = await db.fetchval(
+        "SELECT COUNT(*) FROM votes WHERE plan_round_id = $1",
+        round_id,
+    )
+    if total_votes >= total_members:
+        await db.execute(
+            "UPDATE plan_rounds SET status = 'votes_complete' WHERE id = $1 AND status = 'voting_open'",
+            round_id,
+        )
+
     return {
         "vote_id": "ok",
         "rankings": serialized_rankings,
@@ -382,26 +526,30 @@ async def get_voting_results(
         "SELECT rankings FROM votes WHERE plan_round_id = $1",
         round_id,
     )
-    first_choices = _first_choice_counts(votes)
+    total_votes = len(votes)
 
     total_members = await db.fetchval(
         "SELECT COUNT(*) FROM group_members WHERE group_id = $1 AND status = 'active'",
         group_id,
     )
 
-    consensus = False
-    winning_plan_id = None
-    if first_choices and total_members:
-        max_votes = max(first_choices.values())
-        if max_votes >= (total_members / 2) + 1:
-            winning_plan_id = max(first_choices, key=first_choices.get)
-            consensus = True
+    consensus, winning_plan_id, first_choices = _determine_consensus(votes, total_members)
+
+    # If consensus was found, persist the winning plan on the round.
+    if consensus and winning_plan_id:
+        await db.execute(
+            "UPDATE plan_rounds SET winning_plan_id = $1 WHERE id = $2 AND winning_plan_id IS NULL",
+            UUID(winning_plan_id),
+            round_id,
+        )
 
     return {
         "consensus": consensus,
         "winning_plan_id": winning_plan_id,
         "vote_summary": first_choices,
         "iteration_count": 1,
+        "votes_in": total_votes,
+        "total_members": total_members,
     }
 
 
@@ -521,7 +669,7 @@ async def finalize_plan(group_id: UUID, round_id: UUID, user_id: UUID) -> dict[s
         raise BadRequestError("Cannot finalize without a winning plan")
 
     plan = await db.fetchrow(
-        "SELECT id, title, date_time FROM plans WHERE id = $1",
+        "SELECT id, title, description, location, date_time FROM plans WHERE id = $1",
         winning_id,
     )
     if not plan:
@@ -550,8 +698,49 @@ async def finalize_plan(group_id: UUID, round_id: UUID, user_id: UUID) -> dict[s
         round_id,
     )
 
+    # Send event confirmation emails with .ics to all group members.
+    await _send_event_finalized_notifications(
+        group_id=group_id,
+        plan_title=plan["title"],
+        event_date=event_row["event_date"],
+        location=plan["location"],
+        description=plan["description"],
+    )
+
     return {
         "event_id": str(event_row["id"]),
         "plan_title": plan["title"],
         "event_date": event_row["event_date"].isoformat(),
     }
+
+
+async def _send_event_finalized_notifications(
+    group_id: UUID,
+    plan_title: str,
+    event_date: datetime,
+    location: str | None = None,
+    description: str | None = None,
+) -> None:
+    """Send event finalization emails with .ics to all active group members."""
+    try:
+        group = await db.fetchrow("SELECT name FROM groups WHERE id = $1", group_id)
+        group_name = group["name"] if group else "your group"
+        members = await db.fetch(
+            """
+            SELECT u.email FROM group_members gm
+            JOIN users u ON gm.user_id = u.id
+            WHERE gm.group_id = $1 AND gm.status = 'active'
+            """,
+            group_id,
+        )
+        for member in members:
+            send_event_finalized_email(
+                to_email=member["email"],
+                group_name=group_name,
+                plan_title=plan_title,
+                event_date=event_date,
+                location=location,
+                description=description,
+            )
+    except Exception:
+        logger.exception("Failed to send event finalized emails for group %s", group_id)

--- a/utils/email.py
+++ b/utils/email.py
@@ -1,13 +1,52 @@
-"""Send invite emails via SMTP."""
+"""Send emails via SMTP (invites, voting notifications, event confirmations)."""
 
 import logging
 import smtplib
+from datetime import datetime
+from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email import encoders
 
 from config import get_settings
 
 logger = logging.getLogger(__name__)
+
+
+def _send_email(to_email: str, subject: str, text_body: str, html_body: str, attachments: list | None = None) -> bool:
+    """Low-level SMTP send. Returns True on success."""
+    settings = get_settings()
+    if not settings.smtp_host or not settings.smtp_user:
+        logger.warning("SMTP not configured; skipping email to %s", to_email)
+        return False
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = settings.smtp_from_email or settings.smtp_user
+    msg["To"] = to_email
+    msg.attach(MIMEText(text_body, "plain"))
+    msg.attach(MIMEText(html_body, "html"))
+
+    for attachment in (attachments or []):
+        part = MIMEBase(attachment["maintype"], attachment["subtype"])
+        part.set_payload(attachment["data"])
+        encoders.encode_base64(part)
+        part.add_header("Content-Disposition", f'attachment; filename="{attachment["filename"]}"')
+        msg.attach(part)
+
+    try:
+        with smtplib.SMTP(settings.smtp_host, settings.smtp_port) as server:
+            server.ehlo()
+            if settings.smtp_port != 25:
+                server.starttls()
+                server.ehlo()
+            server.login(settings.smtp_user, settings.smtp_password)
+            server.sendmail(msg["From"], [to_email], msg.as_string())
+        logger.info("Email sent to %s: %s", to_email, subject)
+        return True
+    except Exception:
+        logger.exception("Failed to send email to %s", to_email)
+        return False
 
 
 def send_invite_email(
@@ -18,11 +57,6 @@ def send_invite_email(
 ) -> bool:
     """Send an invitation email. Returns True on success, False otherwise."""
     settings = get_settings()
-
-    if not settings.smtp_host or not settings.smtp_user:
-        logger.warning("SMTP not configured; skipping invite email to %s", to_email)
-        return False
-
     frontend_url = settings.frontend_url.rstrip("/")
     accept_url = f"{frontend_url}/invites/{group_id}?action=accept"
     decline_url = f"{frontend_url}/invites/{group_id}?action=decline"
@@ -46,7 +80,6 @@ def send_invite_email(
             <span style="font-size: 32px;">🍅</span>
             <h1 style="font-size: 22px; color: #c92a2a; margin: 8px 0 0 0;">Ketchup</h1>
         </div>
-
         <p style="font-size: 16px; line-height: 1.6;">
             <strong>{inviter_name}</strong> invited you to join
             <strong>"{group_name}"</strong> on Ketchup.
@@ -54,7 +87,6 @@ def send_invite_email(
         <p style="font-size: 14px; color: #555; line-height: 1.6;">
             Ketchup helps groups coordinate plans and decisions.
         </p>
-
         <div style="text-align: center; margin: 32px 0;">
             <a href="{accept_url}"
                style="display: inline-block; background: #c92a2a; color: #fff;
@@ -69,7 +101,6 @@ def send_invite_email(
                 Decline
             </a>
         </div>
-
         <p style="font-size: 13px; color: #868e96; text-align: center; margin-top: 32px;">
             This invite expires in <strong>24 hours</strong>. If you don't respond,
             it will be automatically declined.
@@ -77,23 +108,153 @@ def send_invite_email(
     </div>
     """
 
-    msg = MIMEMultipart("alternative")
-    msg["Subject"] = subject
-    msg["From"] = settings.smtp_from_email or settings.smtp_user
-    msg["To"] = to_email
-    msg.attach(MIMEText(text_body, "plain"))
-    msg.attach(MIMEText(html_body, "html"))
+    return _send_email(to_email, subject, text_body, html_body)
 
-    try:
-        with smtplib.SMTP(settings.smtp_host, settings.smtp_port) as server:
-            server.ehlo()
-            if settings.smtp_port != 25:
-                server.starttls()
-                server.ehlo()
-            server.login(settings.smtp_user, settings.smtp_password)
-            server.sendmail(msg["From"], [to_email], msg.as_string())
-        logger.info("Invite email sent to %s for group %s", to_email, group_name)
-        return True
-    except Exception:
-        logger.exception("Failed to send invite email to %s", to_email)
-        return False
+
+def send_voting_open_email(
+    to_email: str,
+    group_name: str,
+    group_id: str,
+    round_id: str,
+) -> bool:
+    """Notify a group member that a new voting round is open."""
+    settings = get_settings()
+    frontend_url = settings.frontend_url.rstrip("/")
+    vote_url = f"{frontend_url}/groups/{group_id}/vote/{round_id}"
+
+    subject = f"🍅 Time to vote! New plans for \"{group_name}\" on Ketchup"
+
+    text_body = (
+        f"Hey!\n\n"
+        f"New plans have been generated for \"{group_name}\" on Ketchup.\n"
+        f"Head over to vote on your favorites:\n\n"
+        f"{vote_url}\n\n"
+        f"Voting is open for 24 hours.\n\n"
+        f"- The Ketchup Team"
+    )
+
+    html_body = f"""\
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                max-width: 560px; margin: 0 auto; padding: 32px 24px; color: #1a1a1a;">
+        <div style="text-align: center; margin-bottom: 32px;">
+            <span style="font-size: 32px;">🍅</span>
+            <h1 style="font-size: 22px; color: #c92a2a; margin: 8px 0 0 0;">Ketchup</h1>
+        </div>
+        <p style="font-size: 16px; line-height: 1.6;">
+            New plans have been generated for <strong>"{group_name}"</strong>!
+        </p>
+        <p style="font-size: 14px; color: #555; line-height: 1.6;">
+            Rank your top 5 picks so your group can reach a consensus.
+        </p>
+        <div style="text-align: center; margin: 32px 0;">
+            <a href="{vote_url}"
+               style="display: inline-block; background: #c92a2a; color: #fff;
+                      padding: 12px 32px; border-radius: 6px; text-decoration: none;
+                      font-weight: 600; font-size: 15px;">
+                Vote now
+            </a>
+        </div>
+        <p style="font-size: 13px; color: #868e96; text-align: center; margin-top: 32px;">
+            Voting is open for <strong>24 hours</strong>.
+        </p>
+    </div>
+    """
+
+    return _send_email(to_email, subject, text_body, html_body)
+
+
+def _build_ics(
+    title: str,
+    event_date: datetime,
+    location: str | None = None,
+    description: str | None = None,
+) -> str:
+    """Build a minimal .ics (iCalendar) string for a single event."""
+    from datetime import timedelta
+    import uuid as _uuid
+
+    dtstart = event_date.strftime("%Y%m%dT%H%M%SZ")
+    dtend = (event_date + timedelta(hours=2)).strftime("%Y%m%dT%H%M%SZ")
+    uid = f"{_uuid.uuid4()}@ketchup"
+    dtstamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Ketchup//EN",
+        "BEGIN:VEVENT",
+        f"UID:{uid}",
+        f"DTSTAMP:{dtstamp}",
+        f"DTSTART:{dtstart}",
+        f"DTEND:{dtend}",
+        f"SUMMARY:{title}",
+    ]
+    if location:
+        lines.append(f"LOCATION:{location}")
+    if description:
+        lines.append(f"DESCRIPTION:{description[:200]}")
+    lines.extend(["END:VEVENT", "END:VCALENDAR"])
+    return "\r\n".join(lines)
+
+
+def send_event_finalized_email(
+    to_email: str,
+    group_name: str,
+    plan_title: str,
+    event_date: datetime,
+    location: str | None = None,
+    description: str | None = None,
+) -> bool:
+    """Send event confirmation email with .ics calendar attachment."""
+    settings = get_settings()
+    date_str = event_date.strftime("%B %d, %Y at %I:%M %p")
+
+    subject = f"🍅 It's a plan! \"{plan_title}\" for {group_name}"
+
+    text_body = (
+        f"Hey!\n\n"
+        f"Your group \"{group_name}\" has finalized an event:\n\n"
+        f"  {plan_title}\n"
+        f"  Date: {date_str}\n"
+        f"  Location: {location or 'TBD'}\n\n"
+        f"A calendar invite (.ics file) is attached.\n\n"
+        f"- The Ketchup Team"
+    )
+
+    html_body = f"""\
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                max-width: 560px; margin: 0 auto; padding: 32px 24px; color: #1a1a1a;">
+        <div style="text-align: center; margin-bottom: 32px;">
+            <span style="font-size: 32px;">🍅</span>
+            <h1 style="font-size: 22px; color: #c92a2a; margin: 8px 0 0 0;">Ketchup</h1>
+        </div>
+        <p style="font-size: 16px; line-height: 1.6;">
+            Your group <strong>"{group_name}"</strong> has finalized an event!
+        </p>
+        <div style="background: #f8f9fa; border-radius: 8px; padding: 20px; margin: 24px 0;">
+            <h2 style="font-size: 18px; margin: 0 0 12px 0;">{plan_title}</h2>
+            <p style="font-size: 14px; margin: 4px 0; color: #555;">
+                📅 {date_str}
+            </p>
+            <p style="font-size: 14px; margin: 4px 0; color: #555;">
+                📍 {location or 'TBD'}
+            </p>
+        </div>
+        <p style="font-size: 14px; color: #555; line-height: 1.6;">
+            A calendar invite is attached — add it to your calendar so you don't forget!
+        </p>
+        <p style="font-size: 13px; color: #868e96; text-align: center; margin-top: 32px;">
+            Have fun! 🎉
+        </p>
+    </div>
+    """
+
+    ics_content = _build_ics(plan_title, event_date, location, description)
+    attachments = [{
+        "maintype": "text",
+        "subtype": "calendar",
+        "data": ics_content.encode("utf-8"),
+        "filename": "ketchup-event.ics",
+    }]
+
+    return _send_email(to_email, subject, text_body, html_body, attachments=attachments)


### PR DESCRIPTION
- Renamed "Availability" to "Busy Times" across nav and settings page Redesigned settings page from single "Add block" card to a 7-day accordion (Mon–Sun) with inline block editing per day
- Added first-time user onboarding: new users without availability blocks are redirected to settings with a welcome banner before accessing the dashboard
- Piped availability block locations (e.g., "Mon 9-5: Snell Library") into the AI planning agent context for smarter venue suggestions

Group Preferences:

- Removed "Default Location" field — app is now hardcoded to Boston and Greater Boston, MA
- Added "Location context: All activities MUST be in Boston and Greater Boston, MA area" to AI planning prompt
- Fixed activity likes/dislikes not displaying after save (JSONB deserialization safety with Array.isArray + json.loads fallback on both backend and frontend)
- Added privacy hint: "Only you and the AI can see your likes and dislikes"

Voting & Consensus:

- Fixed Borda voting consensus for small groups: scaled margin threshold by voter count and added tie-breaking Strategy 3 for ≤3 voters
- Fixed Results button navigating to voting page instead of results page for completed rounds
- Added 3 distinct voting result states: "Waiting for votes" (with vote count), "No consensus yet" (role-based messaging for lead vs member), and "Consensus reached"
- Replaced meaningless "anchor" vibe_type on consensus view with event date/time, venue name, address, and estimated cost

Plan Generation & Refinement:

- Merged "Generate 5 Plans" and "Refine (new 5 plans)" into a single smart button that adapts based on context, with an optional refinement modal offering "Regenerate with guidance" / "Skip — just regenerate"
- Hidden plan generation buttons when upcoming (unfinished) events exist
- Fixed round numbering to reset per hangout cycle (Round 1 after each finalized event, not cumulative)
- Strengthened budget_friendly refinement: forceful prompt constraint requiring all plans under $15/person, updated search seeds to prioritize free activities

Feedback:

- Feedback page now pre-populates with the user's prior submission when revisiting
- Shows other members' feedback (read-only) below the form
- Submit button changes to "Update feedback" when editing existing feedback